### PR TITLE
tables: escape double quotes for C# compatibility

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -1095,7 +1095,7 @@ func TestUnmarshalPtrPtr(t *testing.T) {
 
 func TestEscape(t *testing.T) {
 	const input = `"foobar"<html>` + " [\u2028 \u2029]"
-	const expected = `"\"foobar\"\u003Chtml\u003E [\u2028 \u2029]"`
+	const expected = `"\u0022foobar\u0022\u003Chtml\u003E [\u2028 \u2029]"`
 	b, err := Marshal(input)
 	if err != nil {
 		t.Fatalf("Marshal error: %v", err)

--- a/encode.go
+++ b/encode.go
@@ -914,7 +914,7 @@ func (e *encodeState) string(s string, escapeHTML bool) int {
 				e.WriteString(s[start:i])
 			}
 			switch b {
-			case '\\', '"':
+			case '\\':
 				e.WriteByte('\\')
 				e.WriteByte(b)
 			case '\n':
@@ -927,7 +927,7 @@ func (e *encodeState) string(s string, escapeHTML bool) int {
 				e.WriteByte('\\')
 				e.WriteByte('t')
 			default:
-				// This encodes bytes < 0x20 except for \t, \n and \r.
+				// This encodes bytes < 0x20 and " except for \t, \n and \r.
 				// If escapeHTML is set, it also escapes <, >, and &
 				// because they can lead to security holes when
 				// user-controlled strings are rendered into JSON
@@ -1001,7 +1001,7 @@ func (e *encodeState) stringBytes(s []byte, escapeHTML bool) int {
 				e.Write(s[start:i])
 			}
 			switch b {
-			case '\\', '"':
+			case '\\':
 				e.WriteByte('\\')
 				e.WriteByte(b)
 			case '\n':
@@ -1014,7 +1014,7 @@ func (e *encodeState) stringBytes(s []byte, escapeHTML bool) int {
 				e.WriteByte('\\')
 				e.WriteByte('t')
 			default:
-				// This encodes bytes < 0x20 except for \t, \n and \r.
+				// This encodes bytes < 0x20 and " except for \t, \n and \r.
 				// If escapeHTML is set, it also escapes <, >, and &
 				// because they can lead to security holes when
 				// user-controlled strings are rendered into JSON

--- a/encode_test.go
+++ b/encode_test.go
@@ -79,7 +79,7 @@ type StringTag struct {
 var stringTagExpected = `{
  "BoolStr": "true",
  "IntStr": "42",
- "StrStr": "\"xzbit\""
+ "StrStr": "\u0022xzbit\u0022"
 }`
 
 func TestStringTag(t *testing.T) {
@@ -207,7 +207,7 @@ func TestRefValMarshal(t *testing.T) {
 		V2: 15,
 		V3: new(ValText),
 	}
-	const want = `{"R0":"ref","R1":"ref","R2":"\"ref\"","R3":"\"ref\"","V0":"val","V1":"val","V2":"\"val\"","V3":"\"val\""}`
+	const want = `{"R0":"ref","R1":"ref","R2":"\u0022ref\u0022","R3":"\u0022ref\u0022","V0":"val","V1":"val","V2":"\u0022val\u0022","V3":"\u0022val\u0022"}`
 	b, err := Marshal(&s)
 	if err != nil {
 		t.Fatalf("Marshal: %v", err)
@@ -256,7 +256,7 @@ func TestMarshalerEscaping(t *testing.T) {
 	}
 
 	var ct CText
-	want = `"\"\u003C\u0026\u003E\""`
+	want = `"\u0022\u003C\u0026\u003E\u0022"`
 	b, err = Marshal(ct)
 	if err != nil {
 		t.Fatalf("Marshal(ct): %v", err)
@@ -611,6 +611,7 @@ var encodeStringTests = []struct {
 	{"\x1e", `"\u001E"`},
 	{"\x1f", `"\u001F"`},
 	{"'", `"\u0027"`},
+	{"\"", `"\u0022"`},
 }
 
 func TestEncodeString(t *testing.T) {

--- a/stream_test.go
+++ b/stream_test.go
@@ -100,7 +100,7 @@ func TestEncoderSetEscapeHTML(t *testing.T) {
 		want       string
 	}{
 		{"c", c, `"\u003C\u0026\u003E"`, `"<&>"`},
-		{"ct", ct, `"\"\u003C\u0026\u003E\""`, `"\"<&>\""`},
+		{"ct", ct, `"\u0022\u003C\u0026\u003E\u0022"`, `"\u0022<&>\u0022"`},
 		{`"<&>"`, "<&>", `"\u003C\u0026\u003E"`, `"<&>"`},
 	} {
 		var buf bytes.Buffer


### PR DESCRIPTION
Ref https://github.com/nspcc-dev/neo-go/issues/3284.