### PR TITLE
workflows: drop macos-12 runner support

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -45,12 +45,10 @@ jobs:
     strategy:
       matrix:
         go_versions: [ '1.22', '1.23' ]
-        os: [ubuntu-22.04, windows-2022, macos-12, macos-14]
+        os: [ubuntu-22.04, windows-2022, macos-14]
         exclude:
           # Only latest Go version for Windows and MacOS.
           - os: windows-2022
-            go_versions: '1.22'
-          - os: macos-12
             go_versions: '1.22'
           - os: macos-14
             go_versions: '1.22'


### PR DESCRIPTION
Support for macos-12 will be deprecated 10/7/24 and the image will be fully unsupported by 12/3/24. Ref.
actions/runner-images#10721.

Get rid of the build warning:
```
A brownout will take place on November 4, 14:00 UTC - November 5, 00:00
UTC to raise awareness of the upcoming macOS-12 environment removal.
```